### PR TITLE
gluon/firefox: fix css for native titlebar

### DIFF
--- a/gluon/browser/firefox.js
+++ b/gluon/browser/firefox.js
@@ -61,6 +61,15 @@ user_pref('privacy.window.maxInnerHeight', ${windowSize[1]}); */
 .tab-content {
   height: 42px;
 }
+
+:not(html[tabsintitlebar="true"]) #titlebar,
+:not(html[tabsintitlebar="true"]) .tabbrowser-tab,
+:not(html[tabsintitlebar="true"]) .tab-background,
+:not(html[tabsintitlebar="true"]) .tab-content,
+:not(html[tabsintitlebar="true"]) #tabbrowser-tabs,
+:not(html[tabsintitlebar="true"]) .tab-icon-image {
+  display: none !important;
+}
 `);
 
   const proc = spawn(browserPath, [


### PR DESCRIPTION
This PR adjusts the userChrome.css to properly support environments where Firefox's custom titlebar is not used, i.e. most Linux desktops.
